### PR TITLE
CSUB-551: Distinguish era 0 from era data unsynced

### DIFF
--- a/src/contexts/Network/defaults.ts
+++ b/src/contexts/Network/defaults.ts
@@ -11,6 +11,7 @@ import type {
 export const activeEra: ActiveEra = {
   index: new BigNumber(0),
   start: new BigNumber(0),
+  isPlaceholder: true,
 };
 export const metrics: NetworkMetrics = {
   totalIssuance: new BigNumber(0),

--- a/src/contexts/Network/index.tsx
+++ b/src/contexts/Network/index.tsx
@@ -80,6 +80,7 @@ export const NetworkMetricsProvider = ({
             {
               index: new BigNumber(newActiveEra.index),
               start: new BigNumber(newActiveEra.start),
+              isPlaceholder: false,
             },
             setActiveEra,
             activeEraRef

--- a/src/contexts/Network/types.ts
+++ b/src/contexts/Network/types.ts
@@ -17,5 +17,5 @@ export interface NetworkMetrics {
 export interface ActiveEra {
   index: BigNumber;
   start: BigNumber;
-  isPlaceholder?: boolean;
+  isPlaceholder: boolean;
 }

--- a/src/contexts/Network/types.ts
+++ b/src/contexts/Network/types.ts
@@ -17,4 +17,5 @@ export interface NetworkMetrics {
 export interface ActiveEra {
   index: BigNumber;
   start: BigNumber;
+  isPlaceholder?: boolean;
 }

--- a/src/contexts/Staking/index.tsx
+++ b/src/contexts/Staking/index.tsx
@@ -225,7 +225,7 @@ export const StakingProvider = ({
    * the minimum nominator bond is calculated by summing a particular bond of a nominator.
    */
   const fetchEraStakers = async () => {
-    if (!isReady || activeEra.index.isZero() || !api) {
+    if (!isReady || activeEra.isPlaceholder || !api) {
       return;
     }
     const exposuresRaw = await api.query.staking.erasStakers.entries(

--- a/src/contexts/UI/index.tsx
+++ b/src/contexts/UI/index.tsx
@@ -140,7 +140,7 @@ export const UIProvider = ({ children }: { children: React.ReactNode }) => {
     }
 
     // era has synced from Network
-    if (activeEra.index.isZero()) {
+    if (activeEra.isPlaceholder) {
       syncing = true;
       networkSyncing = true;
       poolSyncing = true;

--- a/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
+++ b/src/pages/Overview/Stats/ActiveEraTimeLeft.tsx
@@ -34,8 +34,8 @@ export const ActiveEraStat = () => {
     label: t('overview.timeRemainingThisEra'),
     timeleft: timeleft.formatted,
     graph: {
-      value1: activeEra.index.isZero() ? 0 : percentSurpassed.toNumber(),
-      value2: activeEra.index.isZero() ? 100 : percentRemaining.toNumber(),
+      value1: activeEra.isPlaceholder ? 0 : percentSurpassed.toNumber(),
+      value2: activeEra.isPlaceholder ? 100 : percentRemaining.toNumber(),
     },
     tooltip: `Era ${new BigNumber(activeEra.index).toFormat()}` ?? undefined,
     helpKey: 'Era',


### PR DESCRIPTION
When the data about the current era has not been fetched from the network yet, the `activeEra` 's index is set to a default value of `0`. Then, elsewhere in the code, the network is considered "unsynced" if the `activeEra` index is `0` (effectively using it as a sentinel value).

The problem is that testnet is still currently _on_ era 0. And that's like, a valid era.

This PR resolves this by adding an optional field `isPlaceholder` which, when set to true, indicates that the era data isn't synced yet - using this as a sentinel value instead of 0.