### PR TITLE
Give Mainnet a unique namespace in the networks config

### DIFF
--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -14,7 +14,7 @@ export const NetworkList: Networks = {
       rpc: 'wss://mainnet.creditcoin.network/ws',
       lightClient: null,
     },
-    namespace: '09573a3526818a8ecd6eb92f60f1175d',
+    namespace: 'creditcoin-mainnet',
     api: {
       unit: 'CTC',
       priceTicker: 'CTCUSDT',


### PR DESCRIPTION
Give mainnet a unique namespace to make sure switching networks refreshes all available data.